### PR TITLE
feat!: Prisma Int @id maps to GraphQL Int

### DIFF
--- a/src/generator/models/declaration.ts
+++ b/src/generator/models/declaration.ts
@@ -200,6 +200,7 @@ export function fieldTypeToGraphQLType(field: DMMF.Field): LiteralUnion<Standard
     case 'scalar': {
       const typeName = field.type as PrismaScalarType
 
+      // TODO Allow user to configure this. Maybe some users want Prisma `Int @id` to be GraphQL `ID`.
       if (field.isId && field.type === 'String') {
         return StandardgraphQLScalarTypes.ID
       }

--- a/src/generator/models/declaration.ts
+++ b/src/generator/models/declaration.ts
@@ -200,7 +200,7 @@ export function fieldTypeToGraphQLType(field: DMMF.Field): LiteralUnion<Standard
     case 'scalar': {
       const typeName = field.type as PrismaScalarType
 
-      if (field.isId) {
+      if (field.isId && field.type === 'String') {
         return StandardgraphQLScalarTypes.ID
       }
 

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/modelScalarFields.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/modelScalarFields.test.ts.snap
@@ -852,7 +852,7 @@ export const SomeModel: $Types.SomeModel
 // N/A –– You have not defined any models in your Prisma schema file."
 `;
 
-exports[`A model field with type Int, attribute @id, maps to GraphQL ID scalar 1`] = `
+exports[`A model field with type Int, attribute @id, maps to GraphQL Int scalar 1`] = `
 "import * as Nexus from 'nexus'
 import * as NexusCore from 'nexus/dist/core'
 
@@ -941,7 +941,7 @@ declare namespace $Types {
       /**
        * The type of this field.
        */
-      type: NexusCore.NexusNonNullDef<'ID'>
+      type: NexusCore.NexusNonNullDef<'Int'>
     
       /**
        * The documentation of this field.

--- a/tests/unit/typescriptDeclarationFile/modelScalarFields.test.ts
+++ b/tests/unit/typescriptDeclarationFile/modelScalarFields.test.ts
@@ -10,7 +10,7 @@ it('A model field with type String, attribute @id, maps to GraphQL ID scalar', a
   expect(indexdts).toMatchSnapshot()
 })
 
-it('A model field with type Int, attribute @id, maps to GraphQL ID scalar', async () => {
+it('A model field with type Int, attribute @id, maps to GraphQL Int scalar', async () => {
   const { indexdts } = await generateModules(`
     model SomeModel {
       id Int @id


### PR DESCRIPTION
Only String Id fields should be mapped to scalar ID.

closes #22

