### PR TITLE
Allow customization of prisma client import

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "dependencies": {
     "@prisma/generator-helper": "^2.22.1",
+    "charlie": "^0.0.5",
     "debug": "^4.3.1",
     "endent": "^2.0.1",
     "fs-jetpack": "^4.1.0",

--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -4,7 +4,6 @@
 
 process.env.DEBUG_COLORS = 'true'
 process.env.DEBUG_HIDE_DATE = 'true'
-
 import { generatorHandler } from '@prisma/generator-helper'
 import * as Path from 'path'
 import { generateRuntimeAndEmit } from '../generator'
@@ -26,7 +25,15 @@ generatorHandler({
   },
   // async required by interface
   // eslint-disable-next-line
-  async onGenerate({ dmmf }) {
+  async onGenerate({ dmmf, otherGenerators }) {
+    const prismaClientGenerator = otherGenerators.find((g) => g.provider.value === 'prisma-client-js')
+
+    if (!Gentime.settings.data.prismaClientLocation && prismaClientGenerator?.output?.value) {
+      Gentime.changeSettings({
+        prismaClientLocation: prismaClientGenerator?.output?.value,
+      })
+    }
+
     const internalDMMF = externalToInternalDmmf(dmmf)
     loadUserGentimeSettings()
     generateRuntimeAndEmit(internalDMMF, Gentime.settings)

--- a/src/generator/gentime/settingsSingleton.ts
+++ b/src/generator/gentime/settingsSingleton.ts
@@ -21,6 +21,10 @@ export namespace Gentime {
            */
           GraphQLDocs?: boolean
         }
+    /**
+     * Location of your generated prisma client.
+     */
+    prismaClientLocation?: string | null
   }
 
   export type SettingsData = Setset.InferDataFromInput<SettingsInput>
@@ -45,6 +49,9 @@ export namespace Gentime {
             initial: () => true,
           },
         },
+      },
+      prismaClientLocation: {
+        initial: () => null,
       },
     },
   })

--- a/src/generator/models/javascript.ts
+++ b/src/generator/models/javascript.ts
@@ -56,7 +56,7 @@ export function createModuleSpec(gentimeSettings: Gentime.Settings): ModuleSpec 
 
       const gentimeSettings = ${JSON.stringify(gentimeSettings.data, null, 2)}
 
-      const dmmf = getPrismaClientDmmf()
+      const dmmf = getPrismaClientDmmf(gentimeSettings.prismaClientLocation)
 
       const models = ModelsGenerator.JS.createNexusTypeDefConfigurations(dmmf, {
         runtime: Runtime.settings,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,6 +1705,11 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+charlie@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/charlie/-/charlie-0.0.5.tgz#0984487a938616b2d6c0bc1c2ad1cf698a3f7dcc"
+  integrity sha1-CYRIepOGFrLWwLwcKtHPaYo/fcw=
+
 checkpoint-client@1.1.20:
   version "1.1.20"
   resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.20.tgz#c869eeba84130ea3e5660b1fd71440981b5df8f5"


### PR DESCRIPTION
closes #47

#### TODO

- [ ] docs
- [ ] tests

Pretty simple change that injects the prisma schema output directory into the settings, while also letting it be set directly. Not sure if this is the best approach - but it brings support for setting the `output` option on the prisma client generato9r.