### PR TITLE
feat(settings): allow customization of prisma client import

### DIFF
--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -28,9 +28,9 @@ generatorHandler({
   async onGenerate({ dmmf, otherGenerators }) {
     const prismaClientGenerator = otherGenerators.find((g) => g.provider.value === 'prisma-client-js')
 
-    if (!Gentime.settings.data.prismaClientLocation && prismaClientGenerator?.output?.value) {
+    if (!Gentime.settings.data.prismaClientLocation) {
       Gentime.changeSettings({
-        prismaClientLocation: prismaClientGenerator?.output?.value,
+        prismaClientLocation: prismaClientGenerator?.output?.value || '@prisma/client',
       })
     }
 

--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -32,7 +32,7 @@ generatorHandler({
     // otherwise we will overwrite the user's choice for this setting if they have set it.
     if (prismaClientGenerator?.output?.value) {
       Gentime.settings.change({
-        prismaClientLocation: prismaClientGenerator.output.value
+        prismaClientImportId: prismaClientGenerator.output.value
       })
     }
 

--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -28,9 +28,11 @@ generatorHandler({
   async onGenerate({ dmmf, otherGenerators }) {
     const prismaClientGenerator = otherGenerators.find((g) => g.provider.value === 'prisma-client-js')
 
-    if (!Gentime.settings.data.prismaClientLocation) {
-      Gentime.changeSettings({
-        prismaClientLocation: prismaClientGenerator?.output?.value || '@prisma/client',
+    // WARNING: Make sure this logic comes before `loadUserGentimeSettings` below 
+    // otherwise we will overwrite the user's choice for this setting if they have set it.
+    if (prismaClientGenerator?.output?.value) {
+      Gentime.settings.change({
+        prismaClientLocation: prismaClientGenerator.output.value
       })
     }
 

--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -28,11 +28,11 @@ generatorHandler({
   async onGenerate({ dmmf, otherGenerators }) {
     const prismaClientGenerator = otherGenerators.find((g) => g.provider.value === 'prisma-client-js')
 
-    // WARNING: Make sure this logic comes before `loadUserGentimeSettings` below 
+    // WARNING: Make sure this logic comes before `loadUserGentimeSettings` below
     // otherwise we will overwrite the user's choice for this setting if they have set it.
     if (prismaClientGenerator?.output?.value) {
       Gentime.settings.change({
-        prismaClientImportId: prismaClientGenerator.output.value
+        prismaClientImportId: prismaClientGenerator.output.value,
       })
     }
 

--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -4,7 +4,6 @@
 
 process.env.DEBUG_COLORS = 'true'
 process.env.DEBUG_HIDE_DATE = 'true'
-
 import { generatorHandler } from '@prisma/generator-helper'
 import * as Path from 'path'
 import { generateRuntimeAndEmit } from '../generator'
@@ -26,7 +25,15 @@ generatorHandler({
   },
   // async required by interface
   // eslint-disable-next-line
-  async onGenerate({ dmmf }) {
+  async onGenerate({ dmmf, otherGenerators }) {
+    const prismaClientGenerator = otherGenerators.find((g) => g.provider.value === 'prisma-client-js')
+
+    if (!Gentime.settings.data.prismaClientLocation && prismaClientGenerator?.output?.value) {
+      Gentime.changeSettings({
+        prismaClientLocation: prismaClientGenerator?.output?.value,
+      })
+    }
+
     const internalDMMF = externalToInternalDmmf(dmmf)
     loadUserGentimeSettings()
     generateRuntimeAndEmit(internalDMMF, Gentime.settings)

--- a/src/generator/gentime/settingsSingleton.ts
+++ b/src/generator/gentime/settingsSingleton.ts
@@ -37,7 +37,7 @@ export namespace Gentime {
      * @remarks Nexus Prisma imports Prisma client internally for two reasons: 1) validation wherein a class reference to Prisma Client is needed for some `instanceof` checks and 2) for acquiring the DMMF as Nexus Prisma relies on some post-processing done by Prisma Client generator.
      * 
      */
-    prismaClientLocation?: string | null
+     prismaClientImportId?: string | null
   }
 
   export type SettingsData = Setset.InferDataFromInput<SettingsInput>

--- a/src/generator/gentime/settingsSingleton.ts
+++ b/src/generator/gentime/settingsSingleton.ts
@@ -21,6 +21,10 @@ export namespace Gentime {
            */
           GraphQLDocs?: boolean
         }
+    /**
+     * Location of your generated prisma client.
+     */
+    prismaClientLocation?: string | null
   }
 
   export type SettingsData = Setset.InferDataFromInput<SettingsInput>
@@ -45,6 +49,9 @@ export namespace Gentime {
             initial: () => true,
           },
         },
+      },
+      prismaClientLocation: {
+        initial: () => null,
       },
     },
   })

--- a/src/generator/gentime/settingsSingleton.ts
+++ b/src/generator/gentime/settingsSingleton.ts
@@ -22,7 +22,20 @@ export namespace Gentime {
           GraphQLDocs?: boolean
         }
     /**
-     * Location of your generated prisma client.
+     * Where Nexus Prisma will try to import your generated Prisma Client from.
+     * 
+     * You should not need to configure this normally because Nexus Prisma generator 
+     * automatically reads the Prisma Client generator `output` setting if you have
+     * set it.
+     *
+     * The value here will be used in a dynamic import thus following Node's path 
+     * resolution rules. You can pass a node_modules package like `foo` `@prisma/client` 
+     * `@my/custom/thing` etc. or you can pass an absolute module/file path `/my/custom/thing` / `/my/custom/thing/index.js` or 
+     * finally a relative path to be resolved relative to the location of Nexus Prisma 
+     * source files (you probably don't want this).
+     *
+     * @remarks Nexus Prisma imports Prisma client internally for two reasons: 1) validation wherein a class reference to Prisma Client is needed for some `instanceof` checks and 2) for acquiring the DMMF as Nexus Prisma relies on some post-processing done by Prisma Client generator.
+     * 
      */
     prismaClientLocation?: string | null
   }
@@ -50,8 +63,8 @@ export namespace Gentime {
           },
         },
       },
-      prismaClientLocation: {
-        initial: () => null,
+      prismaClientImportId: {
+        initial: () => `@prisma/client`,
       },
     },
   })

--- a/src/generator/gentime/settingsSingleton.ts
+++ b/src/generator/gentime/settingsSingleton.ts
@@ -23,21 +23,22 @@ export namespace Gentime {
         }
     /**
      * Where Nexus Prisma will try to import your generated Prisma Client from.
-     * 
-     * You should not need to configure this normally because Nexus Prisma generator 
-     * automatically reads the Prisma Client generator `output` setting if you have
-     * set it.
      *
-     * The value here will be used in a dynamic import thus following Node's path 
-     * resolution rules. You can pass a node_modules package like `foo` `@prisma/client` 
-     * `@my/custom/thing` etc. or you can pass an absolute module/file path `/my/custom/thing` / `/my/custom/thing/index.js` or 
-     * finally a relative path to be resolved relative to the location of Nexus Prisma 
-     * source files (you probably don't want this).
+     * You should not need to configure this normally because Nexus Prisma generator automatically reads the
+     * Prisma Client generator `output` setting if you have set it.
      *
-     * @remarks Nexus Prisma imports Prisma client internally for two reasons: 1) validation wherein a class reference to Prisma Client is needed for some `instanceof` checks and 2) for acquiring the DMMF as Nexus Prisma relies on some post-processing done by Prisma Client generator.
-     * 
+     * The value here will be used in a dynamic import thus following Node's path resolution rules. You can
+     * pass a node_modules package like `foo` `@prisma/client`
+     * `@my/custom/thing` etc. or you can pass an absolute module/file path `/my/custom/thing` /
+     * `/my/custom/thing/index.js` or finally a relative path to be resolved relative to the location of Nexus
+     * Prisma source files (you probably don't want this).
+     *
+     * @remarks Nexus Prisma imports Prisma client internally for two reasons: 1) validation wherein a
+     *          class reference to Prisma Client is needed for some `instanceof` checks and 2) for
+     *          acquiring the DMMF as Nexus Prisma relies on some post-processing done by Prisma Client
+     *          generator.
      */
-     prismaClientImportId?: string | null
+    prismaClientImportId?: string | null
   }
 
   export type SettingsData = Setset.InferDataFromInput<SettingsInput>

--- a/src/generator/models/javascript.ts
+++ b/src/generator/models/javascript.ts
@@ -56,7 +56,7 @@ export function createModuleSpec(gentimeSettings: Gentime.Settings): ModuleSpec 
 
       const gentimeSettings = ${JSON.stringify(gentimeSettings.data, null, 2)}
 
-      const dmmf = getPrismaClientDmmf(gentimeSettings.prismaClientLocation)
+      const dmmf = getPrismaClientDmmf(gentimeSettings.prismaClientImportId)
 
       const models = ModelsGenerator.JS.createNexusTypeDefConfigurations(dmmf, {
         runtime: Runtime.settings,

--- a/src/generator/models/javascript.ts
+++ b/src/generator/models/javascript.ts
@@ -56,7 +56,7 @@ export function createModuleSpec(gentimeSettings: Gentime.Settings): ModuleSpec 
 
       const gentimeSettings = ${JSON.stringify(gentimeSettings.data, null, 2)}
 
-      const dmmf = getPrismaClientDmmf()
+      const dmmf = getPrismaClientDmmf(gentimeSettings.prismaClientLocation)
 
       const models = ModelsGenerator.JS.createNexusTypeDefConfigurations(dmmf, {
         runtime: Runtime.settings,


### PR DESCRIPTION
closes #47

Brings support for the `output` option in the prisma client generator. Also allows you to set this location manually via the settings option. Maybe a better way at doing this as I didn't spend too much time looking through the library - but it works for both cases (manually setting or using the settings function).

#### TODO

- [ ] docs
- [ ] tests
