### PR TITLE
fix: remove bad prisma client on ctx check & export $settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ query {
   $settings({
     prismaClientImportId: '@my/custom/thing',
   })
+  ```
 
 ### Generator Settings
 

--- a/src/generator/gentime/settingsSingleton.ts
+++ b/src/generator/gentime/settingsSingleton.ts
@@ -8,7 +8,7 @@ export namespace Gentime {
      * @default 'Int'
      */
     projectIdIntToGraphQL?: 'ID' | 'Int'
-	// TODO add some examples
+    // TODO add some examples
     /**
      * Should Prisma Schema docs propagate as docs?
      *
@@ -82,7 +82,7 @@ export namespace Gentime {
     },
   })
 
-  export function changeSettings(input: Setset.UserInput<SettingsInput>): Settings {
-    return settings.change(input)
+  export function changeSettings(input: Setset.UserInput<SettingsInput>): void {
+    settings.change(input)
   }
 }

--- a/src/generator/models/declaration.ts
+++ b/src/generator/models/declaration.ts
@@ -116,6 +116,19 @@ export function renderTypeScriptDeclarationForDocumentModels(
             })
             .join('\n\n')
     }
+
+    //
+    //
+    // EXPORTS: OTHER
+    // EXPORTS: OTHER
+    // EXPORTS: OTHER
+    // EXPORTS: OTHER
+    //
+    //
+
+    import { Runtime } from '../generator/runtime/settingsSingleton'
+
+    export const $settings = Runtime.changeSettings
   `
 }
 

--- a/src/generator/models/declaration.ts
+++ b/src/generator/models/declaration.ts
@@ -1,4 +1,5 @@
 import { DMMF } from '@prisma/generator-helper'
+import * as OS from 'os'
 import dedent from 'dindist'
 import { LiteralUnion } from 'type-fest'
 import { StandardGraphQLScalarType, StandardgraphQLScalarTypes } from '../../helpers/graphql'
@@ -32,7 +33,8 @@ export function renderTypeScriptDeclarationForDocumentModels(
   const models = dmmf.datamodel.models
   const enums = dmmf.datamodel.enums
 
-  return dedent`
+  return (
+    dedent`
     import * as Nexus from 'nexus'
     import * as NexusCore from 'nexus/dist/core'
 
@@ -129,7 +131,8 @@ export function renderTypeScriptDeclarationForDocumentModels(
     import { Runtime } from '../generator/runtime/settingsSingleton'
 
     export const $settings = Runtime.changeSettings
-  `
+  ` + OS.EOL
+  )
 }
 
 function renderTypeScriptDeclarationForEnum(enum_: DMMF.DatamodelEnum, settings: Gentime.Settings): string {

--- a/src/generator/models/declaration.ts
+++ b/src/generator/models/declaration.ts
@@ -1,6 +1,6 @@
 import { DMMF } from '@prisma/generator-helper'
-import * as OS from 'os'
 import dedent from 'dindist'
+import * as OS from 'os'
 import { LiteralUnion } from 'type-fest'
 import { StandardGraphQLScalarType, StandardgraphQLScalarTypes } from '../../helpers/graphql'
 import { PrismaScalarType } from '../../helpers/prisma'
@@ -130,7 +130,7 @@ export function renderTypeScriptDeclarationForDocumentModels(
 
     import { Runtime } from '../generator/runtime/settingsSingleton'
 
-    export const $settings = Runtime.changeSettings
+    export const $settings: typeof Runtime.changeSettings
   ` + OS.EOL
   )
 }

--- a/src/generator/models/javascript.ts
+++ b/src/generator/models/javascript.ts
@@ -66,7 +66,12 @@ export function createModuleSpec(gentimeSettings: Gentime.Settings): ModuleSpec 
         }
       })
 
-      module.exports = models
+      const moduleExports = {
+        ...models,
+        $settings: Runtime.settings.change,
+      }
+
+      module.exports = moduleExports
     `,
   }
 }

--- a/src/generator/models/javascript.ts
+++ b/src/generator/models/javascript.ts
@@ -170,13 +170,6 @@ export function prismaFieldToNexusResolver(
   }
 
   return (root: RecordUnknown, _args: RecordUnknown, ctx: RecordUnknown): MaybePromise<unknown> => {
-    if (!ctx.prisma) {
-      // TODO rich errors
-      throw new Error(
-        'Prisma client not found in context. Set a Prisma client instance to `prisma` field of Nexus context'
-      )
-    }
-
     const uniqueIdentifiers = resolveUniqueIdentifiers(model)
     const missingIdentifiers = findMissingUniqueIdentifiers(root, uniqueIdentifiers)
 

--- a/src/generator/runtime/settingsSingleton.ts
+++ b/src/generator/runtime/settingsSingleton.ts
@@ -24,7 +24,7 @@ export namespace Runtime {
     },
   })
 
-  export function changeSettings(input: Setset.UserInput<SettingsInput>): Settings {
-    return settings.change(input)
+  export function changeSettings(input: Setset.UserInput<SettingsInput>): void {
+    settings.change(input)
   }
 }

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -171,8 +171,8 @@ it('When bundled custom scalars are used the project type checks and generates e
       content: dedent/*ts*/ `
         require('dotenv').config()
 
-        import { makeSchema, objectType, enumType, queryType, $settings } from 'nexus'
-        import { Bar, Foo, SomeEnumA } from 'nexus-prisma'
+        import { makeSchema, objectType, enumType, queryType } from 'nexus'
+        import { Bar, Foo, SomeEnumA, $settings } from 'nexus-prisma'
         import * as customScalars from 'nexus-prisma/scalars'
         import * as Path from 'path'
 
@@ -297,6 +297,9 @@ it('When bundled custom scalars are used the project type checks and generates e
 
   expect(results.runFirstBuild.exitCode).toBe(2)
 
+  expect(stripAnsi(results.runFirstBuild.stdout)).toMatch(
+    /.*error TS2305: Module '"nexus"' has no exported member '$settings'.*/
+  )
   expect(stripAnsi(results.runFirstBuild.stdout)).toMatch(
     /.*error TS2305: Module '"nexus-prisma"' has no exported member 'Bar'.*/
   )

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -171,10 +171,13 @@ it('When bundled custom scalars are used the project type checks and generates e
       content: dedent/*ts*/ `
         require('dotenv').config()
 
-        import { makeSchema, objectType, enumType, queryType } from 'nexus'
+        import { makeSchema, objectType, enumType, queryType, $settings } from 'nexus'
         import { Bar, Foo, SomeEnumA } from 'nexus-prisma'
         import * as customScalars from 'nexus-prisma/scalars'
         import * as Path from 'path'
+
+        // Show that we can import and call settings as a NOOP
+        $settings({})
         
         const types = [
           customScalars,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -298,7 +298,7 @@ it('When bundled custom scalars are used the project type checks and generates e
   expect(results.runFirstBuild.exitCode).toBe(2)
 
   expect(stripAnsi(results.runFirstBuild.stdout)).toMatch(
-    /.*error TS2305: Module '"nexus-prisma"' has no exported member '$settings'.*/
+    /.*error TS2305: Module '"nexus-prisma"' has no exported member '\$settings'.*/
   )
   expect(stripAnsi(results.runFirstBuild.stdout)).toMatch(
     /.*error TS2305: Module '"nexus-prisma"' has no exported member 'Bar'.*/

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -298,7 +298,7 @@ it('When bundled custom scalars are used the project type checks and generates e
   expect(results.runFirstBuild.exitCode).toBe(2)
 
   expect(stripAnsi(results.runFirstBuild.stdout)).toMatch(
-    /.*error TS2305: Module '"nexus"' has no exported member '$settings'.*/
+    /.*error TS2305: Module '"nexus-prisma"' has no exported member '$settings'.*/
   )
   expect(stripAnsi(results.runFirstBuild.stdout)).toMatch(
     /.*error TS2305: Module '"nexus-prisma"' has no exported member 'Bar'.*/

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/enum.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/enum.test.ts.snap
@@ -120,7 +120,7 @@ export const Foo: $Types.Foo
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -218,6 +218,6 @@ export const Foo: $Types.Foo
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/enum.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/enum.test.ts.snap
@@ -107,7 +107,21 @@ declare namespace $Types {
   *
   * enumType(Foo)
   */
-export const Foo: $Types.Foo"
+export const Foo: $Types.Foo
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`When prisma enum has documentation then it is used for JSDoc and GraphQL enum description: index.d.ts 1`] = `
@@ -191,5 +205,19 @@ declare namespace $Types {
   *
   * enumType(Foo)
   */
-export const Foo: $Types.Foo"
+export const Foo: $Types.Foo
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/enumDoc.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/enumDoc.test.ts.snap
@@ -81,7 +81,21 @@ declare namespace $Types {
   *
   * enumType(Foo)
   */
-export const Foo: $Types.Foo"
+export const Foo: $Types.Foo
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`When an enum has no documentation comment, then it gets the default JSDoc and its description field is null: index.d.ts 1`] = `
@@ -191,5 +205,19 @@ declare namespace $Types {
   *
   * enumType(Foo)
   */
-export const Foo: $Types.Foo"
+export const Foo: $Types.Foo
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/enumDoc.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/enumDoc.test.ts.snap
@@ -94,7 +94,7 @@ export const Foo: $Types.Foo
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -218,6 +218,6 @@ export const Foo: $Types.Foo
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/modelDocumentation.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/modelDocumentation.test.ts.snap
@@ -157,7 +157,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`When a model field has no documentation comment, then it gets the default JSDoc and its description field is null: index.d.ts 1`] = `
@@ -329,7 +343,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`When a model has a documentation comment, then it is used for the JSDoc of that model and its $description field: index.d.ts 1`] = `
@@ -475,7 +503,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`When a model has no documentation comment, then it gets the default JSDoc and its description field is null: index.d.ts 1`] = `
@@ -647,5 +689,19 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/modelDocumentation.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/modelDocumentation.test.ts.snap
@@ -170,7 +170,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -356,7 +356,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -516,7 +516,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -702,6 +702,6 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/modelRelationFields.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/modelRelationFields.test.ts.snap
@@ -442,5 +442,19 @@ export const Post: $Types.Post
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/modelRelationFields.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/modelRelationFields.test.ts.snap
@@ -455,6 +455,6 @@ export const Post: $Types.Post
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/modelScalarFields.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/modelScalarFields.test.ts.snap
@@ -220,7 +220,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`A model field with type DateTime maps to GraphQL DateTime custom scalar: index.d.ts 1`] = `
@@ -443,7 +457,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`A model field with type Float maps to GraphQL Float scalar: index.d.ts 1`] = `
@@ -666,7 +694,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`A model field with type Int maps to GraphQL Int scalar: index.d.ts 1`] = `
@@ -889,7 +931,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`A model field with type Int, attribute @id, maps to GraphQL Int scalar: index.d.ts 1`] = `
@@ -1061,7 +1117,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`A model field with type Json maps to GraphQL Json custom scalar: index.d.ts 1`] = `
@@ -1284,7 +1354,21 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;
 
 exports[`A model field with type String, attribute @id, maps to GraphQL ID scalar: index.d.ts 1`] = `
@@ -1456,5 +1540,19 @@ export const SomeModel: $Types.SomeModel
 //
 //
 
-// N/A –– You have not defined any models in your Prisma schema file."
+// N/A –– You have not defined any models in your Prisma schema file.
+
+//
+//
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+// EXPORTS: OTHER
+//
+//
+
+import { Runtime } from '../generator/runtime/settingsSingleton'
+
+export const $settings = Runtime.changeSettings
+"
 `;

--- a/tests/unit/typescriptDeclarationFile/__snapshots__/modelScalarFields.test.ts.snap
+++ b/tests/unit/typescriptDeclarationFile/__snapshots__/modelScalarFields.test.ts.snap
@@ -233,7 +233,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -470,7 +470,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -707,7 +707,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -944,7 +944,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -1130,7 +1130,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -1367,7 +1367,7 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;
 
@@ -1553,6 +1553,6 @@ export const SomeModel: $Types.SomeModel
 
 import { Runtime } from '../generator/runtime/settingsSingleton'
 
-export const $settings = Runtime.changeSettings
+export const $settings: typeof Runtime.changeSettings
 "
 `;


### PR DESCRIPTION
closes #57

- fix: remove back prisma client ctx check
- fix: Export `$settings` from nexus-prisma package
- fix: Tweak `settings` import from `nexus-prisma/generator` to not return anything, thus not leaking internal `Setset` API.
- improve: trailing newline on generated `.d.ts` file


#### TODO

- [x] ~docs~ https://github.com/prisma/nexus-prisma/issues/61
- [x] tests
